### PR TITLE
Amendment to Core meeting time

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -119,7 +119,7 @@ They will also set the hour and place of meetings, make recommendations to the C
 
 ### 6.3. Meetings
 
-The SF Bay Core will hold regular meetings every Monday morning from 9 a.m. to 12 p.m., unless ordered otherwise by the SF Bay Core.
+The SF Bay Core will hold regular meetings every Monday morning from 11 a.m. to 2 p.m., unless ordered otherwise by the SF Bay Core.
 Special meetings of the SF Bay Core may be called by the Lead Organizer and must be called upon the written request of 2 Core Members.
 
 Meetings are normally open to the public, but advanced request is required.


### PR DESCRIPTION
Core has been regularly rescheduling their weekly meetings to later in
the day. This amendment aligns the Bylaws with their current practice.